### PR TITLE
Utilize active record lazy loading

### DIFF
--- a/lib/active_sort_order.rb
+++ b/lib/active_sort_order.rb
@@ -1,11 +1,15 @@
-require "active_record"
+require "active_sort_order/version"
 
-require "active_sort_order/concerns/sort_order_concern"
+require "active_support/lazy_load_hooks"
 
-module ActiveSortOrder 
-  extend ActiveSupport::Concern
+ActiveSupport.on_load(:active_record) do
+  require "active_sort_order/concerns/sort_order_concern"
 
-  included do
-    include ActiveSortOrder::SortOrderConcern
+  module ActiveSortOrder
+    extend ActiveSupport::Concern
+
+    included do
+      include ActiveSortOrder::SortOrderConcern
+    end
   end
 end


### PR DESCRIPTION
Currently the gem is loaded right away and requires active_record. When this happens, the database configuration is required even to run basic tasks like assets:precompile on a build host, which is suboptimal.

Instead we can utilize lazy loading for active record as is standard with activerecord gems/plugins.